### PR TITLE
Added our current changes and bump to v1.0.2.pre

### DIFF
--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -8,12 +8,12 @@ module Capybara
       raise "Must pass a hash containing 'from' or 'xpath' or 'css'" unless options.is_a?(Hash) and [:from, :xpath, :css].any? { |k| options.has_key? k }
 
       if options.has_key? :xpath
-        select2_container = find(:xpath, options[:xpath])
+        select2_container = first(:xpath, options[:xpath])
       elsif options.has_key? :css
-        select2_container = find(:css, options[:css])
+        select2_container = first(:css, options[:css])
       else
         select_name = options[:from]
-        select2_container = find("label", text: select_name).find(:xpath, '..').find(".select2-container")
+        select2_container = first("label", text: select_name).find(:xpath, '..').find(".select2-container")
       end
 
       # Open select2 field

--- a/gem/lib/capybara-select2.rb
+++ b/gem/lib/capybara-select2.rb
@@ -23,12 +23,14 @@ module Capybara
       elsif select2_container.has_selector?(".select2-choice")
         select2_container.find(".select2-choice").click
       else
-        select2_container.find(".select2-choices").click
+        select2_container.find(".select2-choices .select2-search-field").click
       end
 
       if options.has_key? :search
-        find(:xpath, "//body").find(".select2-search input.select2-search__field").set(value)
-        page.execute_script(%|$("input.select2-search__field:visible").keyup();|)
+        # fix for finding input on select2 < 4
+        search_field = '.select2-search-field input.select2-input, .select2-with-searchbox input.select2-input'
+        find(:xpath, "//body").find(search_field).set(value)
+        page.execute_script(%|$("input.select2-input:visible").keyup();|)
         drop_container = ".select2-results"
       elsif find(:xpath, "//body").has_selector?(".select2-dropdown")
         # select2 version 4.0

--- a/gem/lib/capybara-select2/version.rb
+++ b/gem/lib/capybara-select2/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Select2
-    VERSION = "1.0.1"
+    VERSION = "1.0.2.pre"
   end
 end


### PR DESCRIPTION
* Use first matcher to avoid Capybara::Ambiguous: Ambiguous match
* Fix backward compatibility with select2 <v4.0 when search is specified
* Make sure to select search field on when multiple choices